### PR TITLE
Add mobile padding to resume page

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -778,7 +778,12 @@ footer {
     .post-content {
         font-size: 16px;
     }
-    
+
+    .cv-content {
+        padding-left: 1rem;
+        padding-right: 1rem;
+    }
+
     .cv-header {
         flex-direction: column;
         align-items: flex-start;


### PR DESCRIPTION
## Summary
- add horizontal padding to resume page on small screens to keep text away from edges

## Testing
- `zola build`

------
https://chatgpt.com/codex/tasks/task_e_68af9681dfb483259dfcd11c709ea21e