### PR TITLE
Make about page title blue

### DIFF
--- a/public/style.css
+++ b/public/style.css
@@ -123,7 +123,7 @@ header {
     font-weight: 300;
     letter-spacing: 0.08em;
     margin-bottom: 1rem;
-    color: var(--text-primary);
+    color: var(--accent);
 }
 
 .subtitle {

--- a/static/style.css
+++ b/static/style.css
@@ -123,7 +123,7 @@ header {
     font-weight: 300;
     letter-spacing: 0.08em;
     margin-bottom: 1rem;
-    color: var(--text-primary);
+    color: var(--accent);
 }
 
 .subtitle {


### PR DESCRIPTION
## Summary
- update name header on about page to use blue accent color

## Testing
- `zola build` (fails: command not found)


------
https://chatgpt.com/codex/tasks/task_e_68b1a5544fac8325a6af485cc55469bb